### PR TITLE
Made CLI executable have a more "friendly" name

### DIFF
--- a/src/Localtunnel.Cli/Localtunnel.Cli.csproj
+++ b/src/Localtunnel.Cli/Localtunnel.Cli.csproj
@@ -21,4 +21,9 @@
   <ItemGroup>
     <ProjectReference Include="..\Localtunnel\Localtunnel.csproj" />
   </ItemGroup>
+
+  <Target Name="Rename" AfterTargets="AfterBuild">
+    <Move SourceFiles="$(OUTDIR)\$(MSBuildProjectName).exe" DestinationFiles="$(OUTDIR)\$(ToolCommandName).exe" />
+    <Message Text="Renamed CLI executable to $(ToolCommandName)" Importance="high" />
+  </Target>
 </Project>


### PR DESCRIPTION
Does not break the  internal resource access.
Instead of using Localtunnel.Cli.exe its localtunnel.exe, which also matches the dotnet tool name.